### PR TITLE
Add option to ignore palette in TIF

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ export declare class Image {
   static createFrom(other: Image, options: ImageConstructorOptions): Image;
   static load(
     image: string | ArrayBuffer | Uint8Array,
-    options?: RequestInit,
+    options?: RequestInit | { ignorePalette: boolean },
   ): Promise<Image>;
 
   getRoiManager(): RoiManager;
@@ -149,10 +149,13 @@ export declare class Image {
   // paintPoints
   // paintPolyline
   // paintPolylines
-  paintPolygon(points: Array<Array<number>>, options?: {
-    color?: Array<number>;
-    filled?: boolean;
-  }): Image;
+  paintPolygon(
+    points: Array<Array<number>>,
+    options?: {
+      color?: Array<number>;
+      filled?: boolean;
+    },
+  ): Image;
 
   // paintPolygons
 


### PR DESCRIPTION
add option flag to ignore the color table in type 3 TIF images that have
indexed colors, returning index values as single channel, greyscale
image instead of psuedo-colored, 3 channel RGB